### PR TITLE
Add Magic Flip to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,6 +873,7 @@ saw on your Mac.
 - [wechsel](https://github.com/friedrichweise/wechsel) <img align="bottom" height="13" src="https://badgen.net/github/stars/friedrichweise/wechsel?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/friedrichweise/wechsel?style=flat&label=" /> - manage bluetooth connections with your keyboard.
 - [VolumeGlass](https://github.com/aarush67/VolumeGlass-Code) <img align="bottom" height="13" src="https://badgen.net/github/stars/aarush67/VolumeGlass-Code?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/aarush67/VolumeGlass-Code?style=flat&label=" /> - An iOS-style glass volume indicator for macOS.
 - [YABA](https://github.com/Subfly/YABA) <img align="bottom" height="13" src="https://badgen.net/github/stars/Subfly/YABA?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/Subfly/YABA?style=flat&label=" /> - A modern cross-platform bookmark manager that’s privacy-focused and works offline.
+- [Magic Flip](https://github.com/svekl/magic-flip) <img align="bottom" height="13" src="https://badgen.net/github/stars/svekl/magic-flip?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/svekl/magic-flip?style=flat&label=" /> - Inverts Apple Magic Trackpad for upside down use.
 
 ## VPN & Proxy
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -858,6 +858,7 @@
 - [wechsel](https://github.com/friedrichweise/wechsel) <img align="bottom" height="13" src="https://badgen.net/github/stars/friedrichweise/wechsel?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/friedrichweise/wechsel?style=flat&label=" /> - 使用键盘管理蓝牙连接。
 - [VolumeGlass](https://github.com/aarush67/VolumeGlass-Code) <img align="bottom" height="13" src="https://badgen.net/github/stars/aarush67/VolumeGlass-Code?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/aarush67/VolumeGlass-Code?style=flat&label=" /> - 一款 iOS 风格的玻璃质感 macOS 音量指示器。
 - [YABA](https://github.com/Subfly/YABA) <img align="bottom" height="13" src="https://badgen.net/github/stars/Subfly/YABA?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/Subfly/YABA?style=flat&label=" /> - 一款现代跨平台书签管理器，支持离线使用并保障隐私。
+- [Magic Flip](https://github.com/svekl/magic-flip) <img align="bottom" height="13" src="https://badgen.net/github/stars/svekl/magic-flip?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/svekl/magic-flip?style=flat&label=" /> - 翻转 Apple 妙控板以便倒置使用。
 
 ## 压缩工具
 


### PR DESCRIPTION
Adds [Magic Flip](https://github.com/svekl/magic-flip) — a small open-source (MIT) Swift/SwiftUI menu bar app for macOS 26 (Tahoe) that flips the touch surface of Apple Magic Trackpad to use upside-down so cursor movement matches its physical orientation.

Placed under **Utilities** in both `README.md` and `README.zh.md`, appended at the end of the section to match where recent contributions have been added.

## Checklist

- [x] Added/updated in both `README.md` and `README.zh.md`
- [x] Correct category (Utilities)
- [x] Placement follows the local section structure in each file
- [x] Ordering is consistent with nearby entries
- [x] Description is one concise sentence
- [x] English and Chinese descriptions are semantically aligned
- [x] App entry appears once per intended file
- [x] Link and badges are valid
- [x] Checked final locations with \`rg -n\`
- [x] Reviewed \`git diff\` for only intended listing changes
- [x] No unrelated changes