### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ is list features a curated selection of open-source macOS applications developed
 - [waveSDR](https://github.com/getoffmyhack/waveSDR) <img align="bottom" height="13" src="https://badgen.net/github/stars/getoffmyhack/waveSDR?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/getoffmyhack/waveSDR?style=flat&label=" /> - Software-defined radio app.
 - [VoiceInput](https://github.com/yetone/voice-input-dist) <img align="bottom" height="13" src="https://badgen.net/github/stars/yetone/voice-input-dist?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/yetone/voice-input-dist?style=flat&label=" /> - Real-time speech-to-text tool that types transcribed text into the focused app.
 - [VoiceInk](https://github.com/Beingpax/VoiceInk) <img align="bottom" height="13" src="https://badgen.net/github/stars/Beingpax/VoiceInk?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/Beingpax/VoiceInk?style=flat&label=" /> - Real-time speech-to-text app.
+- [OpenQuack](https://github.com/larryxiao/openquack) <img align="bottom" height="13" src="https://badgen.net/github/stars/larryxiao/openquack?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/larryxiao/openquack?style=flat&label=" /> - Transcribes a 5-minute clip in 2.8 s — local WhisperKit dictation, noise-robust, lives in your menu bar.
 
 ## Backup
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -168,6 +168,7 @@
 - [waveSDR](https://github.com/getoffmyhack/waveSDR) <img align="bottom" height="13" src="https://badgen.net/github/stars/getoffmyhack/waveSDR?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/getoffmyhack/waveSDR?style=flat&label=" /> - 无线电接收应用。
 - [VoiceInput](https://github.com/yetone/voice-input-dist) <img align="bottom" height="13" src="https://badgen.net/github/stars/yetone/voice-input-dist?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/yetone/voice-input-dist?style=flat&label=" /> - 实时语音转文字工具，可将转写内容直接输入到当前聚焦应用。
 - [VoiceInk](https://github.com/Beingpax/VoiceInk) <img align="bottom" height="13" src="https://badgen.net/github/stars/Beingpax/VoiceInk?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/Beingpax/VoiceInk?style=flat&label=" /> - 实时语音转文字工具。
+- [OpenQuack](https://github.com/larryxiao/openquack) <img align="bottom" height="13" src="https://badgen.net/github/stars/larryxiao/openquack?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/larryxiao/openquack?style=flat&label=" /> - 菜单栏本地语音听写工具 — 5 分钟音频 2.8 秒完成；基于 WhisperKit，抗噪，无遥测。
 
 ## 备份
 


### PR DESCRIPTION
Adds [OpenQuack](https://github.com/larryxiao/openquack) to the **Audio** section.

OpenQuack is an MIT-licensed, native Swift menu-bar dictation app for macOS built on WhisperKit (Apple Silicon / Core ML). Transcribes a 5-minute clip in 2.8 s after stop, noise-robust in real office environments, 99 Whisper languages, no telemetry.

- Appended after VoiceInk in `README.md` and `README.zh.md` (append-only section ordering matches the existing pattern)
- Chinese description in `README.zh.md` matches the translation style of neighbouring entries