### PR TITLE
Fix Abendrot entry formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,7 +1067,7 @@ Contributions are welcome via PR, and I will feature your app on my social media
 
 ## System
 
-- [Abendrot](https://abendrot.app) - Free and open-source, warms every display at local sunset. [![Open-Source Software][OSS Icon]](https://github.com/matthewrball/abendrot) ![Freeware][Freeware Icon]
+- [Abendrot](https://github.com/matthewrball/abendrot) <img align="bottom" height="13" src="https://badgen.net/github/stars/matthewrball/abendrot?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/matthewrball/abendrot?style=flat&label=" /> - Free and open-source, warms every display at local sunset.
 - [Apple Juice](https://github.com/raphaelhanneken/apple-juice) <img align="bottom" height="13" src="https://badgen.net/github/stars/raphaelhanneken/apple-juice?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/raphaelhanneken/apple-juice?style=flat&label=" /> - Advanced battery gauge for macOS.
 - [Ampere](https://github.com/az-code-lab/ampere) <img align="bottom" height="13" src="https://badgen.net/github/stars/az-code-lab/ampere?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/az-code-lab/ampere?style=flat&label=" /> - Lightweight menu bar app for monitoring battery status and controlling charging on Apple Silicon Macs.
 - [Battery Hog](https://github.com/luke-fairbanks/BatteryHog) <img align="bottom" height="13" src="https://badgen.net/github/stars/luke-fairbanks/BatteryHog?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/luke-fairbanks/BatteryHog?style=flat&label=" /> - Shows per-app energy use to identify and quit what's draining your battery.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1042,7 +1042,7 @@
 
 ## 系统
 
-- [Abendrot](https://abendrot.app) - 免费开源，在当地日落时温暖每一块显示器。 [![开源软件][OSS Icon]](https://github.com/matthewrball/abendrot) ![免费软件][Freeware Icon]
+- [Abendrot](https://github.com/matthewrball/abendrot) <img align="bottom" height="13" src="https://badgen.net/github/stars/matthewrball/abendrot?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/matthewrball/abendrot?style=flat&label=" /> - 免费开源，在当地日落时温暖每一块显示器。
 - [Apple Juice](https://github.com/raphaelhanneken/apple-juice) <img align="bottom" height="13" src="https://badgen.net/github/stars/raphaelhanneken/apple-juice?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/raphaelhanneken/apple-juice?style=flat&label=" /> - macOS 的高级电池监测工具。
 - [Ampere](https://github.com/az-code-lab/ampere) <img align="bottom" height="13" src="https://badgen.net/github/stars/az-code-lab/ampere?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/az-code-lab/ampere?style=flat&label=" /> - 轻量级菜单栏应用，用于监控电池状态并在 Apple Silicon 设备上控制充电。
 - [Battery Hog](https://github.com/luke-fairbanks/BatteryHog) <img align="bottom" height="13" src="https://badgen.net/github/stars/luke-fairbanks/BatteryHog?style=flat&label=" /> <img align="bottom" height="13" src="https://img.shields.io/github/last-commit/luke-fairbanks/BatteryHog?style=flat&label=" /> - 按应用展示电池能耗，帮助找出并关闭最耗电的程序。


### PR DESCRIPTION
The Abendrot entry uses awesome-mac's reference-style badge labels (`[OSS Icon]`, `[Freeware Icon]`). Those labels are only defined in `jaywcjlove/awesome-mac`, not in this repo, so they render as literal text on the site:

> Abendrot - Free and open-source, warms every display at local sunset. !\[Open-Source Software\]\[OSS Icon\] !\[Freeware\]\[Freeware Icon\]

This switches the entry to this list's format — GitHub repo link plus the stars and last-commit badges — matching every other entry. Same change applied to `README.zh.md`.